### PR TITLE
fix: skip children of missing properties

### DIFF
--- a/validator-e2e/lib/steps/representation/property/index.spec.ts
+++ b/validator-e2e/lib/steps/representation/property/index.spec.ts
@@ -218,7 +218,7 @@ describe('property step', () => {
       const propertyStatement = new PropertyStep({
         propertyId: 'title',
         strict: false,
-      }, [], [])
+      }, [new StepSpy()], [])
       const value: any = {}
 
       // when
@@ -227,6 +227,7 @@ describe('property step', () => {
 
       // then
       expect(result.result!.status).toBe('informational')
+      expect(propertyStatement.children).toHaveLength(0)
     })
 
     it('returns success when comparing resource has expected rdf:type', async () => {

--- a/validator-e2e/lib/steps/representation/property/index.ts
+++ b/validator-e2e/lib/steps/representation/property/index.ts
@@ -55,6 +55,8 @@ export class PropertyStep extends ScenarioStep<HydraResource> {
       }
 
       if (!(step.propertyId in resource)) {
+        step.children = []
+
         return step.__getMissingPropertyResult(resource)
       }
 


### PR DESCRIPTION
Bit of a brute-force approach, but this stops the children of missing properties from being checked in case they are `strict` (and would then always fail in `strict` mode).

Refs https://github.com/hypermedia-app/hypertest/issues/70 and https://github.com/libero/article-store/pull/184.